### PR TITLE
Commit naming convention

### DIFF
--- a/commits_naming.md
+++ b/commits_naming.md
@@ -1,9 +1,5 @@
 # Commits Naming
 
-TODO: Put the automatic ...Mm.. for got the name
-TODO: Fix Typo, if any.
-
-
 <!-- TOC -->
 
 - [Commits Naming](#commits-naming)
@@ -14,17 +10,15 @@ TODO: Fix Typo, if any.
 Every commit of applications of AJK Town must follow the commit writing rules. The fundamental rule is the following
 
 1. You must put the defined prefix of every commit.
-1. Every pull request must be squashed and merged as one commit, and the PR must have its title with the same prefix rule.
 
 
-
-TODO: This table has to be linted correctly on VS Code
 | Type     | Explanation                                                          | Example                       |
 |:---------|:---------------------------------------------------------------------|:------------------------------|
 | feat     | new feature                                                          | feat: button                  |
 | comment  | new comment                                                          | comment: about this button    |
+| todo     | new todo                                                             | todo: add a new button        |
 | refactor | refactor                                                             | refactor: whatever code       |
-| yarn     | run any yarn commands of the package json                            | yarn:inspect                  |
-| fix      | bug, typo or anything wrong but it does not have to be really wrong. | fix: bug, fix: typo, fix: doc |
+| yarn     | run any yarn commands of the package json                            | yarn: inspect, yarn: latest   |
+| fix      | bug, typo or anything wrong but it does not have to be really wrong. | fix: bug, fix: typo           |
 | style    | any style                                                            | style: button, style: app bar |
 | doc      | any document, and documents gets                                     | doc: commit naming convention |


### PR DESCRIPTION
We've added a new commit prefix `todo` for todos