### PR TITLE
 GET/PUT Preference Feature

### DIFF
--- a/api/domain-driven-design.md
+++ b/api/domain-driven-design.md
@@ -15,10 +15,10 @@
     - [fromMdb()](#frommdb)
   - [Non-Static](#non-static)
     - [post()](#post)
-    - [toModel() PRIVATE](#tomodel-private)
+    - [toDoc() PRIVATE](#todoc-private)
     - [toResDTO()](#toresdto)
     - [insert~()](#insert)
-    - [updateFrom~()](#updatefrom)
+    - [updateWith~()](#updatewith)
     - [update() PRIVATE](#update-private)
     - [delete()](#delete)
 
@@ -99,9 +99,9 @@ Returns WordDomain after saving into persistence.
 
 It uses `fromPostDto()` and `toDocument()` methods to save into persistence.
 
-### toModel() PRIVATE
+### toDoc() PRIVATE
 
-Returns model type data that can be saved into persistence.
+Returns doc type data that can be saved into persistence.
 
 It is usually private because it is directly called by post() method.
 
@@ -116,9 +116,15 @@ Certain hidden data won't be visible to the user.
 
 Unlike Update methods, it simply modifies the data without modifying the persistence.
 
-### updateFrom~()
+### updateWith~()
 
 Updates as the properties. Any name can be given with the tilda(~) sign.
+
+
+Examples:
+- updateWithPostedWord
+- updateWithPutDto
+- updateWithDeletedWord
 
 
 ### update() PRIVATE

--- a/api/domain-driven-design.md
+++ b/api/domain-driven-design.md
@@ -9,6 +9,7 @@
     - [Private Constructor](#private-constructor)
     - [get functions](#get-functions)
   - [Static](#static)
+    - [underDevEnv()](#underdevenv)
     - [fromRawDangerously()](#fromrawdangerously)
     - [fromPostDto() PRIVATE](#frompostdto-private)
     - [fromMdbByAtd()](#frommdbbyatd)
@@ -57,6 +58,10 @@ get property() {
 
 
 ## Static
+
+### underDevEnv()
+
+Method only used under development environment. non-dev environment will throw an error.
 
 ### fromRawDangerously()
 

--- a/api/domain-driven-design.md
+++ b/api/domain-driven-design.md
@@ -11,6 +11,7 @@
   - [Static](#static)
     - [fromRawDangerously()](#fromrawdangerously)
     - [fromPostDto() PRIVATE](#frompostdto-private)
+    - [fromMdbByAtd()](#frommdbbyatd)
     - [fromMdb()](#frommdb)
   - [Non-Static](#non-static)
     - [post()](#post)
@@ -69,6 +70,19 @@ Try to delete it as much as possible.
 Return Domain with given DTO (atd is required to write who created the domain)
 
 It is usually private because it is directly called by post() method.
+
+### fromMdbByAtd()
+
+Some of the resources like `support` or `preference` are automatically created by the system.
+
+This method is used to create the domain with the given atd, acquired by successfully signed in user.
+
+Usually the system checks the following thing
+- If it does not exist => Create a new one
+- If it is more than 1 => Error => Leave the first one as the valid one and delete the rest of them
+
+Usually it depends on `fromMdb` method to finally return domain with either newly-created data or existing data.
+
 
 
 ### fromMdb()


### PR DESCRIPTION
# Background
As preference domain is developed on API environment, the standard for `fromMdbByAtd` has been established in https://github.com/ajktown/api/pull/58  and should be documented.

## TODOs
- [x]  Write a doc about fromMdb and fromMdbByAtd
- [x]  Write a doc that fromMdbByAtd always depend on fromMdb

## Related PRs
- https://github.com/ajktown/docs/pull/23
- https://github.com/ajktown/wordnote/pull/101
- https://github.com/ajktown/api/pull/58

## Checklists
- [x] One of the followings is handled
  - At least one or more issue are linked to this PR under `development`
  - [The issue template](https://github.com/ajktown/.github/blob/main/issue_template.md) is directly copied above the `Related PRs`
- [x] `Related PRs` is correctly modified, if it is not `None`
- [x] Assignee is set
- [x] Labels are set
- [x] Title is checked
- [x] `yarn inspect` is run
- [x] Operation Check is done
- [x] `TODOs` of associated issue (or TODOs here, if present) are handled and checked
