### PR TITLE
Domain Interface naming rule

### DIFF
--- a/dev/writing_conventions/api/domain-interface.md
+++ b/dev/writing_conventions/api/domain-interface.md
@@ -1,0 +1,34 @@
+# Domain Interface
+
+<!-- TOC -->
+
+- [Domain Interface](#domain-interface)
+  - [Overview](#overview)
+  - [Managed Prefix](#managed-prefix)
+  - [Managed Name](#managed-name)
+  - [Manged Suffix](#manged-suffix)
+
+<!-- /TOC -->
+
+
+## Overview
+
+Basic rules of writing domain interface with fixed prefix and suffix.
+
+## Managed Prefix
+Every interface related to the domain must start with prefix `I`
+
+## Managed Name
+The Domain must be named the same as it would be stored in DB.
+
+i.e) words (db) => IWord
+
+## Manged Suffix
+AJK Town uses only the following suffixes
+
+|   Suffix   |                                           Description                                           |
+|:----------:|:-----------------------------------------------------------------------------------------------:|
+|   Input    | Used right before creating the domain. If certain data must be created in the constructor phase |
+| (NoSuffix) |                    Props of the domain; has derived properties from `Input`                     |
+|   Shared   |    Used to respond data for shared purpose. It contains less data than the original domain.     |
+|  Derived   |                   Used when mother domain controls the respond of the domain                    |


### PR DESCRIPTION
# Background
Domain has many different interfaces involved and we need to organize suffixes to know right away what the interface is for.


## TODOs
- [x] Document standard

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `Project` is created & linked, if multiple PRs are associated to this PR
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
