### PR TITLE
Derived State for ActionGroupDomain

### DIFF
--- a/dev_api/domains/action-group.md
+++ b/dev_api/domains/action-group.md
@@ -23,7 +23,7 @@ For FEs to easily understand the current state before commitment, AJK Town API o
 - `isLateCommittable`
 - `isDeletable`
 
-These values are derived from the `Action Group State`.
+These values are derived from the `Action Group State`. FEs should create an issue in API if they want to add more derived states. FEs should not use the `Action Group State` directly.
 
 ## Action Group State
 `Action Group State` is the action group's current state for the current date (today). There is only one action group state per one action group.

--- a/dev_api/domains/action-group.md
+++ b/dev_api/domains/action-group.md
@@ -5,6 +5,8 @@
 
 - [Action Group](#action-group)
   - [Overview](#overview)
+  - [Derived State](#derived-state)
+  - [Action Group State](#action-group-state)
   - [Action Group Level](#action-group-level)
   - [Sequence Diagram for Level Decision](#sequence-diagram-for-level-decision)
 
@@ -14,13 +16,62 @@
 
 `Action Group` contains a list of Actions. The main goal is to inject an appropriate level for each action once it is returned to requesters.
 
+## Derived State
+For FEs to easily understand the current state before commitment, AJK Town API offers the following derived state:
+- `isOnTimeCommittable`
+- `isDummyCommittable`
+- `isLateCommittable`
+- `isDeletable`
+
+These values are derived from the `Action Group State`.
+
+## Action Group State
+`Action Group State` is the action group's current state for the current date (today). There is only one action group state per one action group.
+
+
+- Early, OnTime, Late
+- Committed, DummyCommitted, NotCommitted
+
+For example, if it is commiteted on time, the state will be `OnTimeCommitted`
+
+| Time | isCommitted |
+|:--:|:--:|
+| Early | Committed
+| Early | 
+| On Time |
+
+```plantuml
+@startuml
+
+title Action Group State
+
+start
+  if (Has time passed yet?) then (no)
+    :Level is 0;
+    stop
+  else (yes)
+    if (Is Action isDummy==false) then (no)
+      :Level is 1;
+      stop
+    else (yes)
+      if (Is Action createdAt in time (or not late)?) then (no)
+        :Level is 2;
+        stop
+      else (yes)
+      endif
+    endif
+  endif
+  :Level is 4;
+stop
+@enduml
+```
+
 
 ## Action Group Level
 
 Action Group determines the level dynamically based on the following attributes:
 - `Action`'s `createdAt`
 - `Action`'s `isPerformed` (not yet implemented in April 2024)
-
 
 ## Sequence Diagram for Level Decision
 This is a basic sequence diagram for how level is determined:

--- a/dev_api/domains/action-group.md
+++ b/dev_api/domains/action-group.md
@@ -32,40 +32,7 @@ These values are derived from the `Action Group State`.
 - Early, OnTime, Late
 - Committed, DummyCommitted, NotCommitted
 
-For example, if it is commiteted on time, the state will be `OnTimeCommitted`
-
-| Time | isCommitted |
-|:--:|:--:|
-| Early | Committed
-| Early | 
-| On Time |
-
-```plantuml
-@startuml
-
-title Action Group State
-
-start
-  if (Has time passed yet?) then (no)
-    :Level is 0;
-    stop
-  else (yes)
-    if (Is Action isDummy==false) then (no)
-      :Level is 1;
-      stop
-    else (yes)
-      if (Is Action createdAt in time (or not late)?) then (no)
-        :Level is 2;
-        stop
-      else (yes)
-      endif
-    endif
-  endif
-  :Level is 4;
-stop
-@enduml
-```
-
+For example, if it is committed on time, the state will be `OnTimeCommitted`
 
 ## Action Group Level
 

--- a/dev_api/domains/action-group.md
+++ b/dev_api/domains/action-group.md
@@ -34,7 +34,7 @@ start
     :Level is 0;
     stop
   else (yes)
-    if (Is Action isPerformed==true) then (no)
+    if (Is Action isDummy==false) then (no)
       :Level is 1;
       stop
     else (yes)


### PR DESCRIPTION
# Background
The current ConsistencyGPT has its own business logic to allow/disallow clicking certain buttons like:
- Late Commitment
- On Time Commitment
- Delete Commitment

This makes the development of FE more difficult, and should depend on boolean driven data .

## TODOs
- [x] Document the background

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
