### PR TITLE
Doc: `Chunk` and `Group` for API Server Domain Naming Convention

### DIFF
--- a/dev_api/domains/index.hierarchy.md
+++ b/dev_api/domains/index.hierarchy.md
@@ -5,6 +5,7 @@
 - [Domain hierarchy](#domain-hierarchy)
   - [Overview](#overview)
   - [Domain hierarchy](#domain-hierarchy-1)
+  - [About Domain File Namings](#about-domain-file-namings)
 
 <!-- /TOC -->
 
@@ -94,3 +95,14 @@ endswitch
 @enduml
 
 ```
+
+## About Domain File Namings
+
+We use some suffixes to indicate the type of domain. The following is a list of suffixes and their meanings:
+- `Chunk`: Domain with this suffix holds a list of other domains. For example, `WordChunkDomain` holds a list of `WordDomain`.
+- `Group`: Domain with this suffix holds a list of other domains. For example, `RitualActionGroupDomain` holds a list of `RitualActionGroupGroupDomain`.
+
+| Suffix  |                                                         Meaning                                                         | ExistsOnDb |
+|:-------:|:-----------------------------------------------------------------------------------------------------------------------:|:----------:|
+| `Chunk` |   Domain with this suffix holds a list of other domains. For example, `WordDomain` holds a list of `WordChunkDomain`.   |     No     |
+| `Group` | Domain with this suffix holds a list of other domains. For example, `ActionGroupDomain` holds a list of `ActionDomain`. |    Yes     |


### PR DESCRIPTION
# Background
The issue raised [here](https://github.com/ajktown/api/issues/162) concerns the inconsistent use of the suffixes Chunk and Group in domain naming within the AJK Town API.

Upon review, we’ve identified a pattern:
- The suffix `Chunk` is used when the API dynamically manages a list of domains derived from a DB entity.
- The suffix `Group` is used when the domain is directly mapped from a DB entity.

This distinction has emerged through usage, but it may need further clarification or standardization moving forward.

## What's done?
This PR clarifies suffix for Domains in API Server.

## What are the related PRs?
None

## What's next?
Close the following issue once this PR is confirmed and merged: https://github.com/ajktown/api/issues/162

## Checklist Before PR Review
- [x] The following has been handled:
  - `Title` is checked
  - `Background` is filled
  - `What's done?` is filled
  - `What are the related PRs?` is filled
  - `What's next?` is filled
  - `Draft` is set for this PR
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done, if frontend related
  - Make this PR as an open PR
  - Double-check `What's done?` matches to the actual changes
  - Appropriate ajktown/docs sync pr done if needed

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists
  - Check if appropriate issues are created from `What's next?`


